### PR TITLE
Ensure vim always runs from a shell

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -329,3 +329,6 @@ endif
 if filereadable(expand("~/.vimrc.local"))
   source ~/.vimrc.local
 endif
+
+" ensure vim always runs from a shell
+set shell=/bin/sh


### PR DESCRIPTION
Allows MacVim to use the correct ruby version
