### PR TITLE
Run vim-plug setup with nocompatible set

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -1,3 +1,5 @@
+set nocompatible
+
 call plug#begin('~/.vim/plugged')
 
 " Let Vundle manage Vundle


### PR DESCRIPTION
Without this setup.sh runs vim in compatible mode and barfs on plugin line continuations.