### PR TITLE
Remove jk/kj as Esc sequences

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -98,10 +98,6 @@ let g:netrw_liststyle=3
 """ *** MAPPINGS *** """
 """"""""""""""""""""""""
 
-" remap jk and kj to escape in insert mode
-inoremap jk <Esc>
-inoremap kj <Esc>
-
 " Normally Y copies the whole row - not from cursor to EOL like other capitals. This makes it more consistent.
 noremap Y y$
 


### PR DESCRIPTION
This is sometimes annoying to people who don't use it as vim will wait upon a
`j` or `k` keypress before actually inserting the character.

Folks who like this should add this to their `.vimrc.local`. Here for copypastability:

    " remap jk and kj to escape in insert mode
    inoremap jk <Esc>
    inoremap kj <Esc>