### PR TITLE
no remap w

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -148,9 +148,6 @@ vnoremap > >gv
 " :W also saves
 cnoreabbrev W w
 
-" Force Saving Files that Require Root Permission
-cnoremap w!! %!sudo tee > /dev/null %
-
 " Maps more bash-like keys to command line mode (colon mode)
 cnoremap <C-A> <Home>
 cnoremap <C-F> <Right>


### PR DESCRIPTION
This remapping causes a delay of a second or two whenever ':w' is entered into the command row.  Any objections to removing it?
[edit: 'status bar' -> 'command row'...what's the line under the status bar called?]