### PR TITLE
Fenced markdown codeblocks

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -93,6 +93,8 @@ endif
 " netrw tree mode
 let g:netrw_liststyle=3
 
+" Highlight markdown fenced code syntax
+let g:markdown_fenced_languages = ['bash=sh', 'javascript', 'perl', 'python', 'ruby']
 
 """"""""""""""""""""""""
 """ *** MAPPINGS *** """


### PR DESCRIPTION
This enables syntax highlighting for certain languages inside of fenced codeblocks in Markdown documents. Example:

<img width="487" alt="screen shot 2016-02-09 at 6 50 13 pm" src="https://cloud.githubusercontent.com/assets/294415/12934668/561c5618-cf5e-11e5-85de-6b6f814ed4cb.png">
