### PR TITLE
Don't auto-insert when editing commit message

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -213,7 +213,6 @@ endfunction
 
 if has('autocmd')
   au BufNewFile,BufRead COMMIT_EDITMSG setlocal spell!
-  au BufNewFile,BufRead COMMIT_EDITMSG call feedkeys('ggi', 't')
 endif
 
 


### PR DESCRIPTION
This stops vim from putting itself in insert mode when editing commit messages, which is generally unexpected.