### PR TITLE
Automatically toggle between paste and nopaste

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -207,6 +207,23 @@ function! <SID>StripTrailingWhitespaces()
 endfunction
 
 
+""""""""""""""""""""
+""" Auto-Pasting """
+""""""""""""""""""""
+
+" Automatically toggle between paste and nopaste
+" https://coderwall.com/p/if9mda
+let &t_SI .= "\<Esc>[?2004h"
+let &t_EI .= "\<Esc>[?2004l"
+inoremap <special> <expr> <Esc>[200~ XTermPasteBegin()
+
+function! XTermPasteBegin()
+  set pastetoggle=<Esc>[201~
+  set paste
+  return ""
+endfunction
+
+
 """""""""""
 """ GIT """
 """""""""""


### PR DESCRIPTION
This fixes the annoyance when you need to `:set paste` before doing a `Ctrl-V` to prevent it from trying to auto-indent (and usually messing up any existing indentation).

Lifted from https://coderwall.com/p/if9mda/automatically-set-paste-mode-in-vim-when-pasting-in-insert-mode.