### PR TITLE
Add vim-jinja plugin

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -33,6 +33,7 @@ Plug 'nono/vim-handlebars'
 Plug 'digitaltoad/vim-jade'
 Plug 'jshint.vim'
 Plug 'timcharper/textile.vim'
+Plug 'lepture/vim-jinja'
 
 
 Plug 'kien/ctrlp.vim'


### PR DESCRIPTION
This seems to be the most recently maintained version of [the original](https://github.com/mitsuhiko/vim-jinja), which handles filetype detection correctly.