### PR TITLE
Ignore spelling directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 plugged/
 backup/
 .netrwhist
+spell/


### PR DESCRIPTION
NVIM makes a spell/ directory that should be ignored in git