### PR TITLE
Alias `:E` => `:e`

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -150,8 +150,11 @@ vnoremap <silent> . :normal .<CR>
 vnoremap < <gv
 vnoremap > >gv
 
-" :W also saves
+" Alias
+"   :W ➡ :w
 cnoreabbrev W w
+"   :E ➡ :e
+cnoreabbrev E e
 
 " Maps more bash-like keys to command line mode (colon mode)
 cnoremap <C-A> <Home>


### PR DESCRIPTION
For when you hold shift too long and accidentally type `:E` instead of `:e`