### PR TITLE
Remove `:Stree` command

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -169,13 +169,6 @@ set guifont=Menlo:h14
 set antialias
 
 
-""""""""""""""""""
-""" SourceTree """
-""""""""""""""""""
-
-command Stree :silent !stree
-
-
 """"""""""""""""""""""""
 """ *** COMMANDS *** """
 """"""""""""""""""""""""


### PR DESCRIPTION
SourceTree no longer provides an `stree` shell command which this vim command uses.