### PR TITLE
Add plugin for elm

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -36,6 +36,7 @@ Plug 'digitaltoad/vim-jade'
 Plug 'jshint.vim'
 Plug 'timcharper/textile.vim'
 Plug 'lepture/vim-jinja'
+Plug 'elmcast/elm-vim'
 
 
 Plug 'kien/ctrlp.vim'


### PR DESCRIPTION
Adds [`elm-vim`](https://github.com/ElmCast/elm-vim) plugin for Elm syntax highlighting/auto indenting.