### PR TITLE
Use emacs command line plugin instead of mappings

### DIFF
--- a/vimrc
+++ b/vimrc
@@ -156,12 +156,6 @@ vnoremap > >gv
 " :W also saves
 cnoreabbrev W w
 
-" Maps more bash-like keys to command line mode (colon mode)
-cnoremap <C-A> <Home>
-cnoremap <C-F> <Right>
-cnoremap <C-B> <Left>
-cnoremap <M-BS> <C-w>
-
 
 """""""""""""""""""
 """ GUI Options """

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -70,6 +70,7 @@ Plug 'kien/rainbow_parentheses.vim'
 Plug 'rking/ag.vim'
 Plug 'henrik/vim-reveal-in-finder'
 Plug 'justincampbell/vim-eighties'
+Plug 'houtsnip/vim-emacscommandline'
 
 "indent guides
 let g:indent_guides_enable_on_vim_startup = 1


### PR DESCRIPTION
This plugin is more-full featured than our custom, partial solution:
https://github.com/houtsnip/vim-emacscommandline

## Keys I like
Ctrl + e = end of line
Ctrl + a = beginning of line
Meta + f = skip forward to next word 🆕
Meta + b = skip back to next word 🆕
