### PR TITLE
Remove unneeded language plugins

### DIFF
--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -13,15 +13,11 @@ Plug 'tpope/vim-rails'
 Plug 'tpope/vim-bundler'
 Plug 'ecomba/vim-ruby-refactoring'
 Plug 'nelstrom/vim-textobj-rubyblock'
-"   JavaScript
-Plug 'jiangmiao/simple-javascript-indenter'
-Plug 'itspriddle/vim-jquery'
 "   HTML
 Plug 'tudorprodan/html_annoyance.vim'
 "   Other
 Plug 'juvenn/mustache.vim'
 Plug 'digitaltoad/vim-jade'
-Plug 'lepture/vim-jinja'
 
 
 Plug 'kien/ctrlp.vim'

--- a/vimrc.bundles
+++ b/vimrc.bundles
@@ -21,7 +21,6 @@ Plug 'tudorprodan/html_annoyance.vim'
 "   Other
 Plug 'juvenn/mustache.vim'
 Plug 'digitaltoad/vim-jade'
-Plug 'wookiehangover/jshint.vim'
 Plug 'lepture/vim-jinja'
 
 


### PR DESCRIPTION
Follow up to https://github.com/promptworks/promptworks.vim/pull/48

Removes a few more dependancies which are no longer needed for various reasons.
